### PR TITLE
Use Drupal logo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Drupal
-===
+<img alt="Drupal Logo" src="https://www.drupal.org/files/Wordmark_blue_RGB.png" height="60px">
 
 Drupal is an open source content management platform supporting a variety of
 websites ranging from personal weblogs to large community-driven websites. For


### PR DESCRIPTION
Updates the heading to use the Drupal branding. This adds credibility and communicates that this is an official property. 

Additionally, a hyperlink could be included here.